### PR TITLE
fix: resolve Docker version tagging bugs across all build paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,17 +58,23 @@ jobs:
       - name: Determine OpenClaw version
         id: version
         run: |
-          # workflow_call inputs take precedence, then workflow_dispatch, then default
-          VERSION="${{ inputs.openclaw_version || github.event.inputs.openclaw_version || 'main' }}"
-          echo "openclaw_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building OpenClaw version: $VERSION"
+          # Single version source used for both building AND tagging.
+          # Priority: explicit input (workflow_call/dispatch) > VERSION file > 'main'
+          INPUT_VERSION="${{ inputs.openclaw_version }}"
+          FILE_VERSION=$(cat VERSION 2>/dev/null || echo "")
 
-      - name: Read upstream version
-        id: upstream
-        run: |
-          VERSION=$(cat VERSION 2>/dev/null || echo "main")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Upstream version: $VERSION"
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+            echo "Using version from input: $VERSION"
+          elif [[ -n "$FILE_VERSION" ]]; then
+            VERSION="$FILE_VERSION"
+            echo "Using version from VERSION file: $VERSION"
+          else
+            VERSION="main"
+            echo "No version specified, defaulting to: main"
+          fi
+
+          echo "openclaw_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Determine platforms
         id: platforms
@@ -104,7 +110,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=
-            type=raw,value=${{ steps.upstream.outputs.version }},enable=${{ steps.upstream.outputs.version != 'main' }}
+            type=raw,value=${{ steps.version.outputs.openclaw_version }},enable=${{ steps.version.outputs.openclaw_version != 'main' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/watch-releases.yml
+++ b/.github/workflows/watch-releases.yml
@@ -12,6 +12,9 @@ jobs:
       new_release: ${{ steps.check.outputs.new_release }}
       version: ${{ steps.check.outputs.version }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Get latest openclaw release
         id: fetch
         run: |
@@ -21,23 +24,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Restore cached version
-        id: cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .last-version
-          key: openclaw-version-${{ steps.fetch.outputs.version }}
-
       - name: Check if new release
         id: check
         run: |
-          if [ "${{ steps.cache.outputs.cache-hit }}" == "true" ]; then
-            echo "Version ${{ steps.fetch.outputs.version }} already built"
+          CURRENT=$(cat VERSION 2>/dev/null || echo "")
+          LATEST="${{ steps.fetch.outputs.version }}"
+          echo "Current VERSION file: $CURRENT"
+          echo "Latest upstream release: $LATEST"
+          if [ "$CURRENT" == "$LATEST" ]; then
+            echo "Version $LATEST already tracked in VERSION file"
             echo "new_release=false" >> $GITHUB_OUTPUT
           else
-            echo "New release detected: ${{ steps.fetch.outputs.version }}"
+            echo "New release detected: $LATEST (was: $CURRENT)"
             echo "new_release=true" >> $GITHUB_OUTPUT
-            echo "version=${{ steps.fetch.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "version=$LATEST" >> $GITHUB_OUTPUT
           fi
 
   update-version:
@@ -71,17 +71,3 @@ jobs:
     permissions:
       contents: read
       packages: write
-
-  update-cache:
-    needs: [check-release, build]
-    if: needs.check-release.outputs.new_release == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create version file
-        run: echo "${{ needs.check-release.outputs.version }}" > .last-version
-
-      - name: Save version to cache
-        uses: actions/cache/save@v4
-        with:
-          path: .last-version
-          key: openclaw-version-${{ needs.check-release.outputs.version }}


### PR DESCRIPTION
Five interconnected issues caused Docker images to be tagged with wrong
or missing version tags:

1. Race condition in watch-releases: build.yml checked out the repo at
   the workflow start SHA, but the VERSION file was updated by a prior
   job during the same run. The build read the stale VERSION file and
   tagged images with the PREVIOUS version instead of the new one.

2. Two disconnected version sources in build.yml: one step determined
   the version from inputs (for build-arg), another read the VERSION
   file (for Docker tag). These could get out of sync.

3. Push-triggered builds defaulted openclaw_version to 'main' when no
   input was provided, building from OpenClaw main branch but tagging
   from the VERSION file — the tag didn't match what was actually built.

4. build-base.yml chain triggered build.yml without passing a version,
   hitting the same mismatch as (3).

5. GitHub Actions cache for tracking built versions expired after 7
   days of inactivity, causing redundant rebuilds of already-tracked
   versions.

Fixes:
- build.yml: merge two version steps into one. Priority chain:
  explicit input > VERSION file > 'main'. Same version used for both
  the OPENCLAW_VERSION build-arg and the Docker image tag.
- watch-releases.yml: replace fragile cache-based detection with
  direct comparison of upstream release against the VERSION file in
  the repo. Remove the update-cache job entirely.

https://claude.ai/code/session_01DPCV4CCZE5qdUgUaKB3bJn